### PR TITLE
Update regex for parseSync so we always ignore lines starting with #

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -63,7 +63,7 @@ module.exports = {
 			const result = {}
 			const lines = src.toString().split('\n')
 			for ( const line of lines ) {
-				const match = line.match(/^([^=:]+?)[=\:](.*)/)
+				const match = line.match(/^([^=:#]+?)[=\:](.*)/)
 				if ( match ) {
 					const key = match[1].trim()
 					const value = match[2].trim()

--- a/source/test.js
+++ b/source/test.js
@@ -17,4 +17,16 @@ describe('envfile', function (describe, it) {
 			done()
 		})
 	})
+
+	it('comments should be ignored', function (done) {
+		const envfile2jsonPath = pathUtil.join(__dirname, '..', 'bin', 'envfile2json.js')
+		const json2envfilePath = pathUtil.join(__dirname, '..', 'bin', 'json2envfile.js')
+		const command = `echo "#comments with = are ignored\\na=1\\n" | node ${envfile2jsonPath} | node ${json2envfilePath}`
+		process.env.DEBUG_ESNEXTGUARDIAN = ''
+		exec(command, function (err, stdout) {
+			errorEqual(err, null, 'no error to exist')
+			equal(stdout.trim(), 'a=1', 'stdout to be as expected')
+			done()
+		})
+	})
 })


### PR DESCRIPTION
I have added a test that includes one comment line, and updated the regular expression such that any line starting with a '#' but also containing a '=' is ignored.