### PR TITLE
Data is actually just a Record<string, string>

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -1,7 +1,7 @@
 /** Parse an envfile string */
-export function parse<T>(src: string): T {
+export function parse(src: string): Record<string, string> {
 	// Try parse envfile string
-	const result: { [key: string]: any } = {}
+	const result: { [key: string]: string } = {}
 	const lines = src.toString().split('\n')
 	for (const line of lines) {
 		const match = line.match(/^([^=:#]+?)[=:](.*)/)
@@ -11,7 +11,7 @@ export function parse<T>(src: string): T {
 			result[key] = value
 		}
 	}
-	return result as T
+	return result
 }
 
 /** Turn an object into an envfile string */


### PR DESCRIPTION
I think the types on `parse()` could be improved. It's using a generic which doesn't make sense imo. `result` is always an object, and since `const value` is always a string, `result` should be typed as `{ [key: string]: string }`. `parse()` returns `result`, and as such its return type should just be `Record<string, string>`.