### PR TITLE
normalize quotes for values in .env

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -14,7 +14,7 @@ export function parse(src: string): Data {
 		const match = line.match(/^([^=:#]+?)[=:](.*)/)
 		if (match) {
 			const key = match[1].trim()
-			const value = match[2].trim()
+			const value = match[2].trim().replace(/['"]+/g, '')
 			result[key] = value
 		}
 	}

--- a/source/test.ts
+++ b/source/test.ts
@@ -4,6 +4,7 @@ import kava from 'kava'
 import safeps from 'safeps'
 import { resolve } from 'path'
 import { readJSON } from '@bevry/json'
+import { parse } from './index.js'
 
 import filedirname from 'filedirname'
 const [file, dir] = filedirname()
@@ -39,5 +40,17 @@ kava.suite('envfile', function (suite, test) {
 			equal(stdout.trim(), 'a=1', 'stdout to be as expected')
 			done()
 		})
+	})
+
+	test('quotes should be preserved', function (done) {
+		const str = `name="bob"\nplanet="earth"\nrace='human'`
+		const expected = {
+			name: 'bob',
+			planet: 'earth',
+			race: 'human',
+		}
+		const result = parse(str)
+
+		equal(result, expected)
 	})
 })

--- a/source/test.ts
+++ b/source/test.ts
@@ -1,5 +1,5 @@
 // Import
-import { equal, errorEqual } from 'assert-helpers'
+import { deepEqual, equal, errorEqual } from 'assert-helpers'
 import kava from 'kava'
 import safeps from 'safeps'
 import { resolve } from 'path'
@@ -42,7 +42,7 @@ kava.suite('envfile', function (suite, test) {
 		})
 	})
 
-	test('quotes should be preserved', function (done) {
+	test('quotes should be preserved and normalized', function (done) {
 		const str = `name="bob"\nplanet="earth"\nrace='human'`
 		const expected = {
 			name: 'bob',
@@ -51,6 +51,7 @@ kava.suite('envfile', function (suite, test) {
 		}
 		const result = parse(str)
 
-		equal(result, expected)
+		deepEqual(result, expected)
+		done()
 	})
 })


### PR DESCRIPTION
In the case that the values of a .env file contain strings:
```
FOO="BAR"
BAZ='BAX'
```
it would be nice to normalize the values before returning them when calling the `parse` function. Currently if a .env file has values that contain quotes (single or double) the quotes are preserved when setting the value on the result object, leading to situations like this `{FOO: '"BAR"'}`. 