### PR TITLE
Include types in the `exports` entry of the `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,10 +157,12 @@
   "exports": {
     "node": {
       "import": "./edition-es2019-esm/index.js",
-      "require": "./edition-es2019/index.js"
+      "require": "./edition-es2019/index.js",
+      "types": "./compiled-types/index.d.ts"
     },
     "browser": {
-      "import": "./edition-browsers/index.js"
+      "import": "./edition-browsers/index.js",
+      "types": "./compiled-types/index.d.ts"
     }
   },
   "deno": "edition-deno/index.ts",


### PR DESCRIPTION
I [tried to use](https://github.com/Shopify/cli/pull/1122) this package from a Typescript project configured to use the `NodeNext` module resolution but it fails to recognize the types because `types` is missing in the `exports` entry of the `package.json`.  This PR adds it.

I'd appreciate if we could release a new version after this change gets merged.

Thanks a lot in advance for the review.