### PR TITLE
feat: handle comment line for parse and stringify

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -4,31 +4,65 @@ export type Data = Record<string, string>
 /** We typecast the value as a string so that it is compatible with envfiles.  */
 export type Input = Record<string, any>
 
+export type ParseOptions = {
+	// This only work when use direct with api, not work via bin
+	keepComments: boolean
+}
+
+export type StringifyOptions = {
+	keepComments: boolean
+}
+
 // perhaps in the future we can use @bevry/json's toJSON and parseJSON and JSON.stringify to support more advanced types
 
 /** Parse an envfile string. */
-export function parse(src: string): Data {
+export function parse(
+	src: string,
+	options: ParseOptions = { keepComments: false }
+): Data {
 	const result: Data = {}
 	const lines = src.toString().split('\n')
-	for (const line of lines) {
+	let notHandleCount = 0
+	for (const [lineIndex, line] of lines.entries()) {
 		const match = line.match(/^([^=:#]+?)[=:](.*)/)
 		if (match) {
 			const key = match[1].trim()
 			const value = match[2].trim().replace(/['"]+/g, '')
 			result[key] = value
+		} else if (options.keepComments && line.trim().startsWith('#')) {
+			const sym = Symbol.for(`comment#${lineIndex - notHandleCount}`)
+			result[sym as any] = line
+		} else {
+			notHandleCount++
 		}
 	}
 	return result
 }
 
 /** Turn an object into an envfile string. */
-export function stringify(obj: Input): string {
-	let result = ''
-	for (const [key, value] of Object.entries(obj)) {
+export function stringify(
+	obj: Input,
+	options: StringifyOptions = { keepComments: false }
+): string {
+	const result = []
+	for (const key of Reflect.ownKeys(obj)) {
+		const value = obj[key as string]
 		if (key) {
-			const line = `${key}=${String(value)}`
-			result += line + '\n'
+			if (
+				typeof key === 'symbol' &&
+				(key as Symbol).toString().startsWith('Symbol(comment')
+			) {
+				if (options.keepComments) {
+					const [_, lineIndex] = (
+						(key as Symbol).description ?? 'comment#0'
+					).split('#')
+					result.splice(parseInt(lineIndex, 10), 0, value)
+				}
+			} else {
+				const line = `${key as string}=${String(value)}`
+				result.push(line)
+			}
 		}
 	}
-	return result
+	return result.join('\n')
 }

--- a/source/test.ts
+++ b/source/test.ts
@@ -4,7 +4,7 @@ import kava from 'kava'
 import safeps from 'safeps'
 import { resolve } from 'path'
 import { readJSON } from '@bevry/json'
-import { parse } from './index.js'
+import { parse, stringify } from './index.js'
 
 import filedirname from 'filedirname'
 const [file, dir] = filedirname()
@@ -23,7 +23,7 @@ kava.test('envfile test prep', function (done) {
 // Test
 kava.suite('envfile', function (suite, test) {
 	test('should work without comments', function (done) {
-		const command = `echo "a=1\\nb:2\\nc = 3\\nd : 4" | node ${binPath} env2json | node ${binPath} json2env`
+		const command = `echo "a=1\nb:2\nc = 3\nd : 4" | node ${binPath} env2json | node ${binPath} json2env`
 		// @ts-ignore
 		safeps.exec(command, { cwd: root }, function (err, stdout) {
 			errorEqual(err, null, 'no error to exist')
@@ -33,7 +33,7 @@ kava.suite('envfile', function (suite, test) {
 	})
 
 	test('comments should be ignored', function (done) {
-		const command = `echo "#comments with = are ignored\\na=1\\n" | node ${binPath} env2json | node ${binPath} json2env`
+		const command = `echo "#comments with = are ignored\na=1\n" | node ${binPath} env2json | node ${binPath} json2env`
 		// @ts-ignore
 		safeps.exec(command, { cwd: root }, function (err, stdout) {
 			errorEqual(err, null, 'no error to exist')
@@ -52,6 +52,26 @@ kava.suite('envfile', function (suite, test) {
 		const result = parse(str)
 
 		deepEqual(result, expected)
+		done()
+	})
+
+	test('comment should be maintain', function (done) {
+		const str = ` #hello\nname="bob"\n#world \nplanet="earth"\nrace='human'`
+		const expected = ` #hello\nname=bob\n#world \nplanet=earth\nrace=human`
+		const options = { keepComments: true }
+		const result = stringify(parse(str, options), options)
+
+		equal(result, expected)
+		done()
+	})
+
+	test('comment should be maintain correct with blank line', function (done) {
+		const str = ` #hello\n\nboo=foo\n\n#world\nhi=he`
+		const expected = ` #hello\nboo=foo\n#world\nhi=he`
+		const options = { keepComments: true }
+		const result = stringify(parse(str, options), options)
+
+		equal(result, expected)
 		done()
 	})
 })


### PR DESCRIPTION
This PR will handle comment line

For simply I don't write a complicated parser to handle it, I just use symbol for handle line with comment

The benefits of use it is didn't break our object when pass to `JSON.stringify` 

This PR also fix tests and add test case for handle comment line correctly

Close #192