### PR TITLE
Support multiline values

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -9,9 +9,9 @@ export type Input = Record<string, any>
 /** Parse an envfile string. */
 export function parse(src: string): Data {
 	const result: Data = {}
-	const lines = src.toString().split('\n')
+	const lines = splitInLines(src)
 	for (const line of lines) {
-		const match = line.match(/^([^=:#]+?)[=:](.*)/)
+		const match = line.match(/^([^=:#]+?)[=:]((.|\n)*)/)
 		if (match) {
 			const key = match[1].trim()
 			const value = match[2].trim().replace(/['"]+/g, '')
@@ -26,9 +26,28 @@ export function stringify(obj: Input): string {
 	let result = ''
 	for (const [key, value] of Object.entries(obj)) {
 		if (key) {
-			const line = `${key}=${String(value)}`
+			const line = `${key}=${jsonValueToEnv(value)}`
 			result += line + '\n'
 		}
 	}
 	return result
+}
+
+function splitInLines(src: string): string[] {
+	return src
+		.replace(/("[\s\S]*?")/g, (_m, cg) => {
+			return cg.replace(/\n/g, '%%LINE-BREAK%%')
+		})
+		.split('\n')
+		.filter((i) => Boolean(i.trim()))
+		.map((i) => i.replace(/%%LINE-BREAK%%/g, '\n'))
+}
+
+function jsonValueToEnv(value: any): string {
+	let processedValue = String(value)
+	processedValue = processedValue.replace(/\n/g, '\\n')
+	processedValue = processedValue.includes('\\n')
+		? `"${processedValue}"`
+		: processedValue
+	return processedValue
 }

--- a/source/test.ts
+++ b/source/test.ts
@@ -8,7 +8,7 @@ import filedirname from 'filedirname'
 import { resolve } from 'path'
 
 // local
-import { parse } from './index.js'
+import { parse, stringify } from './index.js'
 
 // prepare
 const [file, dir] = filedirname()
@@ -45,6 +45,30 @@ kava.suite('envfile', function (suite, test) {
 			race: 'human',
 		}
 		const result = parse(str)
+
+		deepEqual(result, expected)
+		done()
+	})
+
+	test('line breaks inside quotes should be preserved on parse', function (done) {
+		const str = `name="bob\nmarley"\nplanet=earth`
+		const expected = {
+			name: 'bob\nmarley',
+			planet: 'earth',
+		}
+		const result = parse(str)
+
+		deepEqual(result, expected)
+		done()
+	})
+
+	test('line breaks inside quotes should be preserved on stringify', function (done) {
+		const input = {
+			name: 'bob\nmarley',
+			planet: 'earth',
+		}
+		const expected = `name="bob\\nmarley"\nplanet=earth\n`
+		const result = stringify(input)
 
 		deepEqual(result, expected)
 		done()


### PR DESCRIPTION
Adds support for [multiline values](https://hexdocs.pm/dotenvy/dotenv-file-format.html#values):

```
echo -e "a=\"1\n2\"\nb=3" | npm run our:bin env2json
  {"a":"1\n2","b":"3"}

echo '{"a":"1\\n2","b":3}' | npm run our:bin json2env
  a="1\n2"
  b=3
```