### PR TITLE
Preserve line breaks across a parse(stringify()) round-trip

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -7,12 +7,14 @@ export type Input = Record<string, any>
 // perhaps in the future we can use @bevry/json's toJSON and parseJSON and JSON.stringify to support more advanced types
 
 function removeQuotes(str: string) {
-	// Check if the string starts and ends with single or double quotes
-	if (
-		(str.startsWith('"') && str.endsWith('"')) ||
-		(str.startsWith("'") && str.endsWith("'"))
-	) {
-		// Remove the quotes
+	// Double-quoted values: strip the quotes and unescape line breaks, reversing
+	// what stringify does and matching dotenv's double-quote semantics, so that a
+	// value containing a line break survives a parse(stringify(value)) round-trip.
+	if (str.startsWith('"') && str.endsWith('"')) {
+		return str.slice(1, -1).replace(/\\n/g, '\n')
+	}
+	// Single-quoted values: strip the quotes only, leaving the contents raw.
+	if (str.startsWith("'") && str.endsWith("'")) {
 		return str.slice(1, -1)
 	}
 	// If the string is not wrapped in quotes, return it as is

--- a/source/test.ts
+++ b/source/test.ts
@@ -86,4 +86,14 @@ kava.suite('envfile', function (suite, test) {
 		deepEqual(result, expected)
 		done()
 	})
+
+	test('line breaks should survive a parse(stringify()) round-trip', function (done) {
+		const input = {
+			greeting: 'hello\nworld',
+		}
+		const result = parse(stringify(input))
+
+		deepEqual(result, input)
+		done()
+	})
 })


### PR DESCRIPTION
`stringify` escapes a line break to the two characters `\n` and wraps the value in double quotes, but `parse` strips the quotes without reversing that escape. A value that contains a line break therefore does not survive a round-trip through the library's own functions:

```js
const { parse, stringify } = require('envfile')

parse(stringify({ greeting: 'hello\nworld' }))
// => { greeting: 'hello\\nworld' }   a literal backslash-n, not a line break
```

The two existing tests show the intent. "line breaks inside quotes should be preserved on parse" feeds `parse` an actual line break inside quotes, and "...on stringify" checks that `stringify` emits the escaped `\n` form. They were only ever checked in isolation, so composing them silently drops the line break.

`parse` is the inverse of `stringify`, so it should reverse what `stringify` produces. This makes `removeQuotes` unescape `\n` back to a line break for double-quoted values, which matches dotenv's double-quote semantics where `\n` denotes a line break. Single-quoted values are left raw, as in dotenv.

All existing tests still pass unchanged. I added one that runs `parse(stringify(value))` for a value with a line break; reverting the one-line change in `removeQuotes` makes only that new test fail, with the literal backslash-n shown above.
